### PR TITLE
Fixes issue Press Release Import #45

### DIFF
--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -95,7 +95,7 @@ class BlockBuilder {
 const getMetadata = (document, prop) => document.querySelector(`head meta[property='${prop}'], head meta[name='${prop}']`)?.content;
 
 const getPublishDate = (document) => {
-  let publishDate = document.querySelector('.contentcontainer > .cmp-container > .singlesimpleattributeprojection > .cmp-singlesimpleattributeprojection p:nth-child(1) > b')?.textContent;
+  const publishDate = document.querySelector('.contentcontainer > .cmp-container > .singlesimpleattributeprojection > .cmp-singlesimpleattributeprojection p:nth-child(1) > b')?.textContent;
   if (publishDate) { return publishDate.match(/[A-Za-z]+ [0-9]{1,2}, [12][0-9]{3}/)[0]; }
   return document.querySelector('.referenceprojection .calendarattributeprojection .projection-value');
 };

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -94,6 +94,12 @@ class BlockBuilder {
 
 const getMetadata = (document, prop) => document.querySelector(`head meta[property='${prop}'], head meta[name='${prop}']`)?.content;
 
+const getPublishDate = (document) => {
+  let publishDate = document.querySelector('.contentcontainer > .cmp-container > .singlesimpleattributeprojection > .cmp-singlesimpleattributeprojection p:nth-child(1) > b')?.textContent;
+  if (publishDate) { return publishDate.match(/[A-Za-z]+ [0-9]{1,2}, [12][0-9]{3}/)[0]; }
+  return document.querySelector('.referenceprojection .calendarattributeprojection .projection-value');
+};
+
 const extractMetadata = (document) => {
   const metadata = {};
   const metadataProperties = ['og:title', 'description', 'keywords', 'og:image', 'template'];
@@ -108,6 +114,8 @@ const extractMetadata = (document) => {
     img.src = metadata.image;
     metadata.image = img;
   }
+  const publishDate = getPublishDate(document);
+  if (publishDate) { metadata['Publish Date'] = publishDate; }
   return metadata;
 };
 


### PR DESCRIPTION
Fix #45

This adds publish date detection using a few found patterns in insights and press release pages.  There's no gold standard metadata property, it is only found in markup.

Test URLs:
- Before: https://main--stewart--hlxsites.hlx.live/
- After: https://pr-dates--stewart--hlxsites.hlx.live/
