### PR TITLE
feat: implement teaser list and recent articles blocks

### DIFF
--- a/blocks/recent-articles/recent-articles.js
+++ b/blocks/recent-articles/recent-articles.js
@@ -1,0 +1,65 @@
+import { getSearchConfig } from '../../scripts/search-utils.js';
+import { fetchResults } from '../search-results/search-results.js';
+import {
+  buildBlock,
+  decorateBlock,
+  loadBlock,
+  fetchPlaceholders,
+} from '../../scripts/lib-franklin.js';
+
+import { createElement } from '../../scripts/scripts.js';
+
+const buildTeaserListFromResults = async (results, block) => {
+  const { recentArticlesCta } = await fetchPlaceholders();
+  const cta = recentArticlesCta || 'Read more';
+
+  const teasers = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const entry of results) {
+    const teaserElements = [];
+    const {
+      date,
+      path,
+      image,
+      title,
+      description,
+    } = entry;
+
+    const teaserImageElement = createElement('div', {}, createElement('img', { src: image, alt: title }));
+    const teaserDateElement = createElement('p', {}, new Date(date * 1000).toDateString());
+    const teaserContentElement = createElement('div');
+    const teaserTitleElement = createElement('h3', {}, `<a href="${path}" title="${title}">${title}</a>`);
+    const teaserDescriptionElement = createElement('p', {}, description);
+    const teaserLinkElement = createElement('a', {}, `<a href="${path}" title="${cta}">${cta}</a>`);
+
+    teaserContentElement.append(
+      teaserDateElement,
+      teaserTitleElement,
+      teaserDescriptionElement,
+      teaserLinkElement,
+    );
+
+    if (image && !image.includes('default-meta-image')) {
+      teaserElements.push(teaserImageElement);
+    }
+
+    teaserElements.push(teaserContentElement);
+    teasers.push(teaserElements);
+  }
+
+  const teaserListBlock = buildBlock('teaser-list', teasers);
+
+  block.appendChild(teaserListBlock);
+  decorateBlock(teaserListBlock);
+  await loadBlock(teaserListBlock);
+};
+
+export default async function decorate(block) {
+  const config = getSearchConfig(block);
+  const { count } = config;
+  const results = fetchResults(config, '', '', -1).limit(Number(count));
+
+  block.innerHTML = '';
+  buildTeaserListFromResults(results, block);
+}

--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -20,10 +20,6 @@ const classNames = {
   searchResultsPaginationButton: `${blockName}-pagination-button`,
 };
 
-const resetBlock = (block) => {
-  block.innerHTML = '';
-};
-
 const generatePaginationData = (currentPage, totalPages) => {
   if (!currentPage || !totalPages) {
     return null;
@@ -152,7 +148,7 @@ const createResultItem = (entry) => {
 
 const createPagination = (paginationArray, currentPage) => paginationArray.map((page) => createPaginationButton(page, currentPage)).join('');
 
-const fetchResults = (cfg, query, tag, pageNum) => {
+export const fetchResults = (cfg, query, tag, pageNum) => {
   const results = ffetch(cfg.queryIndex)
     .filter((entry) => {
       if (entry.path.startsWith(cfg.path)) {
@@ -310,7 +306,7 @@ async function renderSearchResults(block, cfg, q, tag, page, partial = false) {
 
 export default async function decorate(block) {
   const cfg = getSearchConfig(block);
-  resetBlock(block);
+  block.innerHTML = '';
 
   if (cfg.tagFacet) {
     block.classList.add('tag-facet');

--- a/blocks/teaser-list/teaser-list.css
+++ b/blocks/teaser-list/teaser-list.css
@@ -1,0 +1,92 @@
+main .teaser-list {
+    list-style: none;
+    margin: 0 auto;
+    padding: 0;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: stretch;
+}
+
+main .teaser-list .teaser-list-item {
+    border: .0625rem solid var(--clr-gray-light);
+    box-shadow: .625rem .625rem .9375rem 0 rgb(0 0 0 / 10%);
+    background-color: var(--clr-white);
+    margin: 0 1rem 2rem 1.5rem;
+}
+
+main .teaser-list .teaser-list-item .teaser-list-item-image {
+    width: 100%;
+    height: 0;
+    padding-top: 52%;
+    position: relative;
+    overflow-y: hidden;
+    background-color: var(--clr-gray-light);
+}
+
+main .teaser-list .teaser-list-item .teaser-list-item-image img {
+    position: absolute;
+    top: 0;
+    height: auto;
+    width: 100%;
+}
+
+main .teaser-list .teaser-list-item .teaser-list-item-content {
+    padding: 1.5rem;
+}
+
+main .teaser-list .teaser-list-item .teaser-list-item-title {
+    font-weight: 700;
+    font-size: var(--heading-font-size-s);
+    line-height: 2rem;
+}
+
+main .teaser-list .teaser-list-item .teaser-list-item-subhead {
+    font-size: var(--body-font-size-xxs);
+    color: var(--clr-gray-dark);
+}
+
+main .teaser-list .teaser-list-item .teaser-list-item-link {
+    font-weight: 700;
+    white-space: nowrap;
+    font-size: var(--body-font-size-l);
+}
+
+main .teaser-list .teaser-list-item .teaser-list-item-link::after {
+    border-top: .375rem solid transparent;
+    border-bottom: .375rem solid transparent;
+    border-left: .375rem solid var(--clr-purple);
+    content: "";
+    display: inline-block;
+    height: 0;
+    margin-left: 1.125rem;
+    width: 0;
+    vertical-align: middle;
+}
+
+@media (min-width: 900px) {
+    main .teaser-list .teaser-list-item .teaser-list-item-link::after {
+        border-top:.5rem solid transparent;
+        border-bottom: .5rem solid transparent;
+        border-left: .5rem solid var(--clr-purple);
+        margin-left: 1.5rem;
+    }
+}
+
+@media (min-width: 900px) {
+    main .teaser-list {
+        flex-flow: row wrap;
+        justify-content: center;
+        align-items: stretch;
+        max-width: none;
+    }
+
+    main .teaser-list .teaser-list-item {
+        max-width: 19.25rem;
+        width: 16.25rem;
+        flex-grow: 1;
+    }
+
+    main .teaser-list .teaser-list-item .teaser-list-item-content {
+        padding: 2rem;
+    }
+}

--- a/blocks/teaser-list/teaser-list.js
+++ b/blocks/teaser-list/teaser-list.js
@@ -1,0 +1,46 @@
+const blockName = 'teaser-list';
+
+const classNames = {
+  teaser: `${blockName}-item`,
+  teaserImage: `${blockName}-item-image`,
+  teaserContent: `${blockName}-item-content`,
+  teaserTitle: `${blockName}-item-title`,
+  teaserLink: `${blockName}-item-link`,
+  teaserSubhead: `${blockName}-item-subhead`,
+};
+
+const assignContainerClasses = (teaser) => {
+  const selectors = ['img', 'h3'];
+  const classes = {
+    img: classNames.teaserImage,
+    h3: classNames.teaserContent,
+  };
+
+  [...teaser.children].forEach((child) => {
+    const selector = selectors.find((className) => child.querySelector(className));
+    child.classList.add(classes[selector]);
+  });
+};
+
+const assignContentClasses = (teaser) => {
+  const title = teaser.querySelector('h3');
+  title.classList.add(classNames.teaserTitle);
+
+  const teaserContent = teaser.querySelector(`.${classNames.teaserContent}`);
+  const cta = teaserContent.querySelector(':scope a:not(h3 *)');
+  cta.classList.add(classNames.teaserLink);
+
+  const subhead = teaserContent.querySelector('p:first-child');
+
+  if (subhead) {
+    subhead.classList.add(classNames.teaserSubhead);
+  }
+};
+
+export default async function decorate(block) {
+  [...block.children].forEach((teaser) => {
+    teaser.classList.add(classNames.teaser);
+    assignContainerClasses(teaser);
+    assignContentClasses(teaser);
+  });
+}

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -563,7 +563,11 @@ export function decorateButtons(element) {
     if (a.href !== a.textContent) {
       const up = a.parentElement;
       const twoup = a.parentElement.parentElement;
-      if (!a.querySelector('img')) {
+      /**
+       * teaser-list CTAs were getting the primary button treatment.
+       * Adding this condition for now, this can be cleaned up as part of https://github.com/hlxsites/stewart/issues/57
+       */
+      if (!a.querySelector('img') && !a.closest('.teaser-list')) {
         if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
           a.className = 'button primary'; // default
           up.classList.add('button-container');


### PR DESCRIPTION
Fix #86 

### SUMMARY
This PR introduces two blocks:
- Teaser List: This is a standard, static list of teaser cards which can be authored.
- Recent Articles: This block builds a teaser list out of the most recent articles for a given search config. The number of articles to show (`count`) is configurable at the block level. This is used on the insights and press release pages.

### TEST URLs
**Static Teaser List (About Stewart Page):**
_The awards and accolades section at the bottom_
- Before: https://main--stewart--hlxsites.hlx.live/en/about-stewart
- After: https://feature-teaser-list--stewart--hlxsites.hlx.live/en/about-stewart

**Recent Articles (News Page):**
- Before: https://main--stewart--hlxsites.hlx.page/en/news
- After: https://feature-teaser-list--stewart--hlxsites.hlx.page/en/news

**Recent Articles (Insights Page)**:
- Before: https://main--stewart--hlxsites.hlx.page/en/insights
- After: https://feature-teaser-list--stewart--hlxsites.hlx.page/en/insights
