### PR TITLE
format librarymetadata into a tooltip so previewing library pages looks accurate

### DIFF
--- a/blocks/library-metadata/library-metadata.css
+++ b/blocks/library-metadata/library-metadata.css
@@ -1,0 +1,57 @@
+.library-metadata-container {
+  position: relative;
+}
+
+.library-metadata {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  border-radius: 50%;
+  border: 1px dotted currentcolor;
+  height: 30px;
+  width: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.library-metadata .tooltip {
+  display: none;
+  padding: 1rem;
+}
+
+.library-metadata .tooltip[aria-expanded="true"] {
+  display: block;
+  position: absolute;
+  top: -1rem;
+  left: 3rem;
+  background-color: white;
+  box-shadow: 4px 4px 4px 4px rgba(0 0 0 / 55%);
+  color: black;
+  z-index: 2;
+  width: 40rem;
+  max-width: 50vw;
+  border-radius: 8px;
+}
+
+.library-metadata .tooltip h2 {
+  font-size: 24px;
+  line-height: 1.5;
+}
+
+.library-metadata .tooltip p {
+  line-height: 1.5;
+}
+
+.library-metadata .tooltip[aria-expanded="true"]::before {
+  content: "";
+  position: absolute;
+  border-top: .5rem solid transparent;
+  border-bottom: .5rem solid transparent;
+  border-left: 1rem solid darkred;
+  rotate: 180deg;
+  left: -1rem;
+  top: 1.25rem;
+}

--- a/blocks/library-metadata/library-metadata.css
+++ b/blocks/library-metadata/library-metadata.css
@@ -27,9 +27,9 @@
   position: absolute;
   top: -1rem;
   left: 3rem;
-  background-color: white;
+  background-color: var(--clr-white);
   box-shadow: 4px 4px 4px 4px rgba(0 0 0 / 55%);
-  color: black;
+  color: var(--clr-black);
   z-index: 2;
   width: 40rem;
   max-width: 50vw;
@@ -50,7 +50,7 @@
   position: absolute;
   border-top: .5rem solid transparent;
   border-bottom: .5rem solid transparent;
-  border-left: 1rem solid darkred;
+  border-left: 1rem solid var(--clr-brand-red);
   rotate: 180deg;
   left: -1rem;
   top: 1.25rem;

--- a/blocks/library-metadata/library-metadata.css
+++ b/blocks/library-metadata/library-metadata.css
@@ -32,7 +32,7 @@
   color: var(--clr-black);
   z-index: 2;
   width: 40rem;
-  max-width: 50vw;
+  max-width: 75vw;
   border-radius: 8px;
 }
 

--- a/blocks/library-metadata/library-metadata.css
+++ b/blocks/library-metadata/library-metadata.css
@@ -4,16 +4,16 @@
 
 .library-metadata {
   position: absolute;
-  top: 1rem;
-  left: 1rem;
+  top: .5rem;
+  left: 4px;
   border-radius: 50%;
   border: 1px dotted currentcolor;
-  height: 30px;
-  width: 30px;
+  height: 18px;
+  width: 18px;
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 18px;
+  font-size: 12px;
   cursor: pointer;
 }
 
@@ -25,8 +25,8 @@
 .library-metadata .tooltip[aria-expanded="true"] {
   display: block;
   position: absolute;
-  top: -1rem;
-  left: 3rem;
+  top: -1.25rem;
+  left: 2.25rem;
   background-color: var(--clr-white);
   box-shadow: 4px 4px 4px 4px rgba(0 0 0 / 55%);
   color: var(--clr-black);
@@ -36,6 +36,21 @@
   border-radius: 8px;
 }
 
+@media (min-width: 900px) {
+  .library-metadata {
+    top: 1rem;
+    left: 1rem;
+    height: 30px;
+    width: 30px;
+    font-size: 18px;
+  }
+
+  .library-metadata .tooltip[aria-expanded="true"] {
+    top: -1rem;
+    left: 3rem;
+  }
+}
+
 .library-metadata .tooltip h2 {
   font-size: 24px;
   line-height: 1.5;
@@ -43,6 +58,8 @@
 
 .library-metadata .tooltip p {
   line-height: 1.5;
+  margin-block: 0 1em;
+  font-size: 18px;
 }
 
 .library-metadata .tooltip[aria-expanded="true"]::before {

--- a/blocks/library-metadata/library-metadata.js
+++ b/blocks/library-metadata/library-metadata.js
@@ -1,0 +1,22 @@
+import { readBlockConfig } from '../../scripts/lib-franklin.js';
+
+export default function decorate(block) {
+  const cfg = readBlockConfig(block);
+  if (cfg.name) {
+    block.innerHTML = `<span 
+    class="fa fa-icon fa-question"
+    ></span>
+    <div class="tooltip">
+      <h2>${cfg.name}</h2>
+      <p>${cfg.description}</p>
+    </div>
+    `;
+
+    const tooltip = block.querySelector('.tooltip');
+    tooltip.setAttribute('aria-expanded', 'false');
+    block.querySelector('.fa-question').addEventListener('click', () => {
+      const expanded = tooltip.getAttribute('aria-expanded') === 'true';
+      tooltip.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+    });
+  }
+}


### PR DESCRIPTION
Test URLs:
- After: https://lib-meta--stewart--hlxsites.hlx.page/library/blocks/section-layout
