### PR TITLE
fix: remove default browser border from buttons

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -304,6 +304,7 @@ button {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border: 0;
 }
 
 @media (min-width: 900px) {


### PR DESCRIPTION
With some recent updates, primary buttons are now getting the default browser border, which needs to be removed.

Before:
<img width="292" alt="Screen Shot 2023-08-10 at 10 19 43 AM" src="https://github.com/hlxsites/stewart/assets/9199192/4b24316b-89c5-42a8-b1ee-d1954d8c3b04">

After:
<img width="290" alt="Screen Shot 2023-08-10 at 10 19 51 AM" src="https://github.com/hlxsites/stewart/assets/9199192/80947d44-eaa5-48a3-9979-f0d5593569d4">

Test URLs:
Before: https://main--stewart--hlxsites.hlx.page/en/search-results?q=stewart
After: https://bugfix-button-border--stewart--hlxsites.hlx.page/en/search-results?q=stewart
