### PR TITLE
css of h3, h2 specific to list is removed as it is applied from style.css

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -107,6 +107,22 @@
     flex-basis: 25%;
   }
 
+  .columns.split-33-66 .row .column-1 {
+    flex-basis: 33.333%;
+  }
+
+  .columns.split-33-66 .row .column-2 {
+    flex-basis: 66.666%;
+  }
+
+  .columns.split-25-75 .row .column-1 {
+    flex-basis: 25%;
+  }
+
+  .columns.split-25-75 .row .column-2 {
+    flex-basis: 75%;
+  }
+
   .columns.card .row .column {
     box-shadow: 0 0.25rem 0.25rem 0 rgba(0 0 0 / 25%);
     border: .0625rem solid var(--clr-gray-dark);

--- a/blocks/list/list.css
+++ b/blocks/list/list.css
@@ -60,19 +60,11 @@
 
 .list-container .default-content-wrapper h2 {
   text-align: center;
-  margin-bottom: 2rem;
 }
 
 .list-container.card-wrapper .default-content-wrapper h2 {
   text-align: left;
   margin-bottom: 0.5rem;
-}
-
-.list-container .default-content-wrapper h3 {
-  margin-bottom: 2rem;
-  font-size: var(--body-font-size-l);
-  line-height: 1.375rem;
-  letter-spacing: 0.0113rem;
 }
 
 .list-container .default-content-wrapper p {
@@ -163,14 +155,6 @@
   }
 
   /* Style the default content whihc is ouside of List block - START */
-
-  .list-container .default-content-wrapper h2 {
-    margin-bottom: 4rem;
-  }
-  
-  .list-container .default-content-wrapper h3 {
-    margin-bottom: 4rem;
-  }
 
   .list-container .default-content-wrapper p {
     margin-bottom: 3.5rem;

--- a/blocks/list/list.css
+++ b/blocks/list/list.css
@@ -43,7 +43,7 @@
 }
 
 .list-container ul .list-item .text-wrapper strong {
-  font-size: 1rem;
+  font-size: var(--body-font-size-m);
   line-height: 1.25rem;
   letter-spacing: 0.01rem;
   margin-bottom: 0.5rem;
@@ -95,7 +95,7 @@
 .list-container ul .list-item .text-wrapper h4,
 .list-container ul .list-item .text-wrapper p {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: var(--body-font-size-xs);
   line-height: 1.125rem;
   letter-spacing: 0.0138rem;
 }
@@ -141,7 +141,7 @@
   }
 
   .list-container ul .list-item .text-wrapper strong {
-    font-size: 1.625rem;
+    font-size: var(--body-font-size-xxl);
     line-height: 2.375rem;
     letter-spacing: 0.0163rem;
     margin-bottom: 0;
@@ -173,7 +173,7 @@
 
   .list-container ul .list-item .text-wrapper h4,
   .list-container ul .list-item .text-wrapper p {
-    font-size: 1.375rem;
+    font-size: var(--body-font-size-xl);
     line-height: 2rem;
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -579,7 +579,8 @@ main .section>div {
 
 @media(min-width: 600px) {
   .section.wide {
-    --max-content-width: 100rem; 
+    --max-content-width: 100rem;
+
     padding-inline: 3%;
   }
   


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #128

If your PR introduces a new block/black varaint, please update the block library https://main--stewart--hlxsites.hlx.page/tools/sidekick/library/library.html

Test URLs:
- Before: https://main--stewart--hlxsites.hlx.live/en/customer-type/commercial-title-closing-services
- After: https://list-font--stewart--hlxsites.hlx.live/en/customer-type/commercial-title-closing-services
