### PR TITLE
External links

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,5 +1,10 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
-import { createElement, decorateIcons, wrapImgsInLinks } from '../../scripts/scripts.js';
+import {
+  createElement,
+  decorateIcons,
+  wrapImgsInLinks,
+  decorateLinks,
+} from '../../scripts/scripts.js';
 
 function createIconsList(ele) {
   const list = document.createElement('ul');
@@ -73,6 +78,7 @@ export default async function decorate(block) {
       }
     });
     footer.replaceChildren(firstColumn, secondColumn);
+    decorateLinks(footer);
     block.append(footer);
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -174,7 +174,7 @@ export function decorateLinks(element) {
           a.href = `${url.pathname.replace('.html', '')}${url.search}${url.hash}`;
         } else if (!url.hostname.includes('.stewart.com')) {
           // non local open in a new tab
-          // but if a different stwart.com sub-domain, leave absolute, but don't open in a new tab
+          // but if a different stewart.com sub-domain, leave absolute, don't open in a new tab
           a.target = '_blank';
           a.rel = 'noopener noreferrer';
         }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -165,14 +165,14 @@ export function decorateLinks(element) {
     try {
       if (a.href) {
         const url = new URL(a.href);
-
-        // local links are relative
-        // non local and non email links open in a new tab
         const hostMatch = hosts.some((host) => url.hostname.includes(host));
 
         if (hostMatch) {
+          // local links are rewritten to be relative
           a.href = `${url.pathname.replace('.html', '')}${url.search}${url.hash}`;
-        } else {
+        } else if (!url.hostname.includes('.stewart.com')) {
+          // non local open in a new tab
+          // but if a different stwart.com sub-domain, leave absolute, but don't open in a new tab
           a.target = '_blank';
           a.rel = 'noopener noreferrer';
         }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -165,8 +165,10 @@ export function decorateLinks(element) {
     try {
       if (a.href) {
         const url = new URL(a.href);
-        const hostMatch = hosts.some((host) => url.hostname.includes(host));
+        // protect against maito: links or other weirdness
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') return;
 
+        const hostMatch = hosts.some((host) => url.hostname.includes(host));
         if (hostMatch) {
           // local links are rewritten to be relative
           a.href = `${url.pathname.replace('.html', '')}${url.search}${url.hash}`;


### PR DESCRIPTION
https://adobe-dx-support.slack.com/archives/C04S4UZRW8J/p1692282161284839

changes external link detection so links to Stewart.com subdomains remain in same tab.

Test URLs:
- Before: https://main--stewart--hlxsites.hlx.live/
- After: https://external-links--stewart--hlxsites.hlx.live/
