### PR TITLE
feat: implement office locator and agency locator blocks

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -4,13 +4,8 @@
  * https://www.hlx.live/developer/block-collection/fragment
  */
 
-import {
-  decorateMain,
-} from '../../scripts/scripts.js';
-
-import {
-  loadBlocks,
-} from '../../scripts/lib-franklin.js';
+import { decorateMain } from '../../scripts/scripts.js';
+import { loadBlocks } from '../../scripts/lib-franklin.js';
 
 /**
  * Loads a fragment.

--- a/blocks/locator-results/locator-results.css
+++ b/blocks/locator-results/locator-results.css
@@ -1,0 +1,356 @@
+main .section.locator-results-container,
+main .section>.locator-results-wrapper {
+  padding: 0;
+  margin-inline: initial;
+  max-width: initial;
+}
+
+main .locator-results .locator-results-search-bar {
+  background: linear-gradient(180deg, var(--clr-teal), var(--clr-teal-dark));
+  width: 100%;
+  padding: 4rem 2.5rem;
+  color: var(--clr-white);
+  text-align: left;
+}
+
+main .locator-results .locator-results-search-bar h2 {
+  margin-bottom: 0;
+}
+
+main .locator-results .locator-results-loading-spinner {
+  text-align: center;
+  font-size: 4rem;
+}
+
+main .locator-results i {
+  font-style: normal;
+  display: inline-block;
+}
+
+main .locator-results .locator-results-loading-spinner>i {
+  margin-block-start: 1rem;
+}
+
+main .locator-results.loading .locator-results-loading-spinner {
+  display: block;
+}
+
+main .locator-results .locator-results-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: start;
+}
+
+main .locator-results .locator-results-filter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+main .locator-results .locator-results-view-filter {
+  display: flex;
+  justify-content: center;
+}
+
+main .locator-results .locator-results-filter-button {
+  width: 100%;
+  margin-right: 1rem;
+}
+
+main .locator-results .locator-results-filter-button.active {
+  background-color: var(--clr-white);
+  border-color: var(--clr-white);
+  color: var(--clr-teal);
+}
+
+main .locator-results .locator-results-loader {
+  display: none;
+}
+
+main .locator-results .locator-results-list {
+  list-style: none;
+  margin: 1rem;
+  padding: 0;
+}
+
+main .locator-results .locator-results-list.hide {
+  display: none;
+}
+
+main .locator-results .locator-results-list-item {
+  background-color: var(--clr-white);
+  box-shadow: 0 0.25rem 0.75rem 0 rgba(0 0 0 / 15%);
+  padding: 1rem;
+  margin-block-end: 1.5rem;
+}
+
+main .locator-results .locator-results-list-item h4 {
+  margin-block-end: 1rem;
+  padding-block-end: 1rem;
+  border-bottom: 1px solid var(--clr-gray-dark);
+}
+
+main .locator-results .locator-results-list-item .locator-results-listing-type {
+  color: var(--clr-teal);
+  font-size: 1.125rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  margin-block-end: 2rem;
+  margin-block-start: 1rem;
+}
+
+main .locator-results .locator-results-list-item.indy .locator-results-listing-type {
+  color: var(--clr-purple);
+}
+
+main .locator-results .locator-results-list-item .locator-results-listing-address {
+  display: flex;
+  flex-direction: column;
+}
+
+main .locator-results .locator-results-list-item .locator-results-listing-details>a {
+  font-size: 1rem;
+  padding-right: 2rem;
+  color: var(--clr-teal);
+  font-weight: 600;
+}
+
+main .locator-results .locator-results-list-item.indy .locator-results-listing-details>a {
+  color: var(--clr-purple);
+}
+
+main .locator-results .locator-results-list-item .locator-results-listing-details>a>i {
+  margin-right: 0.5rem;
+}
+
+main .locator-results .locator-results-list-item .locator-results-listing-phone {
+  display: flex;
+  flex-direction: column;
+}
+
+main .locator-results .locator-results-list-item .locator-results-listing-address-1 {
+  flex-basis: 60%;
+  color: var(--clr-teal);
+  font-weight: 600;
+}
+
+main .locator-results .locator-results-list-item.indy .locator-results-listing-address-1 {
+  color: var(--clr-purple);
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+main .locator-results .locator-results-list-item .locator-results-listing-type i {
+  color: var(--clr-white);
+  background-color: var(--clr-teal);
+  padding: 0.5rem;
+  border-radius: 50%;
+  display: flex;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+}
+
+main .locator-results .locator-results-list-item.indy .locator-results-listing-type i {
+  background-color: var(--clr-purple);
+}
+
+main .locator-results .locator-results-list-item .locator-results-listing-contact-info {
+  margin-block-end: 1rem;
+}
+
+main .locator-results .search-results-pagination {
+  margin-block-start: 2rem;
+}
+
+main .locator-results .search-results-pagination.hide,
+main .locator-results .search-results-pagination:empty {
+  display: none;
+}
+
+main .locator-results .search-results-pagination.dark-bg .search-results-pagination-item>button {
+  padding: 0.5rem 0.75rem;
+}
+
+main .locator-results .locator-results-map-container {
+  display: none;
+}
+
+main .locator-results .locator-results-map-container.active {
+  display: block;
+  height: 100vh;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+main .locator-results .locator-results-loading-spinner,
+main .locator-results .locator-results-search-bar.hide,
+main .locator-results.loading .locator-results-search-bar .locator-results-actions,
+main .locator-results.error .locator-results-search-bar .locator-results-actions,
+main .locator-results.error .locator-results-list {
+  display: none;
+}
+
+@media (min-width: 900px) {
+  main .locator-results .search-bar {
+    padding: 4rem 8.5rem;
+  }
+
+  main .locator-results .locator-results-list {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    margin: 0 auto;
+    padding: 5.5rem 1rem;
+    max-width: var(--max-content-width);
+  }
+
+  main .locator-results .locator-results-filter {
+    flex-direction: row;
+    width: auto;
+  }
+
+  main .locator-results .locator-results-list-item {
+    flex-basis: 49%;
+    padding: 1rem 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  main .locator-results .locator-results-list-item .locator-results-listing-contact-info {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  main .locator-results .locator-results-list-item .locator-results-listing-details>a {
+    font-size: 1.25rem;
+  }
+
+  main .locator-results .locator-results-filter-button {
+    min-width: initial;
+    width: auto;
+    font-size: 1.5rem;
+  }
+
+  main .locator-results .search-results-pagination .search-results-pagination-item {
+    margin: 0 0.25rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  main .locator-results .locator-results-actions {
+    flex-direction: row;
+  }
+
+  main .locator-results .search-results-pagination {
+    margin-block-start: 0;
+    margin-left: auto;
+  }
+}
+
+/**
+ * Agency Locator Specific Styles
+ * -----------------------------------------------------------------------------
+ */
+
+/* stylelint-disable-next-line  no-descending-specificity */
+main .locator-results.agency .locator-results-actions {
+  justify-content: flex-end;
+}
+
+main .locator-results.agency .locator-results-listing-title {
+  border-bottom: 0;
+}
+
+main .locator-results.agency .locator-results-listing-address-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+main .locator-results.agency .locator-results-listing-address {
+  line-height: 1.50rem;
+  margin-block-end: 2rem;
+}
+
+main .locator-results.agency .locator-results-listing-other-info {
+  display: flex;
+  flex-direction: row;
+  font-size: 1rem;
+  margin-block-end: 1rem;
+}
+
+main .locator-results.agency .locator-results-listing-other-info>span {
+  margin-right: 2rem;
+}
+
+
+main .locator-results.agency .search-results-pagination .search-results-pagination-item:last-child {
+  margin-right: 0;
+}
+
+/* stylelint-disable-next-line selector-not-notation */
+main .locator-results.agency:not(.loading):not(.error) .locator-results-search-bar h2 {
+  border-bottom: 1px solid var(--clr-gray);
+  padding-block-end: 1rem;
+  margin-block-end: 1rem;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+main .locator-results.agency .locator-results-listing-address-1,
+main .locator-results.agency .locator-results-list-item.indy .locator-results-listing-address-1,
+main .locator-results.agency .locator-results-listing-address-2,
+main .locator-results.agency .locator-results-listing-city {
+  font-size: 1rem;
+  color: var(--clr-black);
+  font-weight: normal;
+}
+
+@media (min-width: 900px) {
+  main .locator-results.agency .locator-results-listing-title {
+    padding-block-start: 3rem;
+  }
+
+  main .locator-results.agency .locator-results-list-item {
+    padding: 0 5rem;
+  }
+}
+
+/**
+ * Map Marker Infobox Styless
+ * -----------------------------------------------------------------------------
+ */
+
+/* stylelint-disable selector-class-pattern */
+main .MicrosoftMap .infobox-body .locator-results-list-item {
+  max-width: 500px;
+  font-size: 1rem;
+  line-height: 1.5;
+  padding: 1.5rem;
+}
+
+main .MicrosoftMap .infobox-body .locator-results .locator-results-list-item .locator-results-listing-title {
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+main .MicrosoftMap .close-button {
+  cursor: pointer;
+  position: absolute;
+  top: -10px;
+  right: -7px;
+  background: black;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  color: var(--clr-white);
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: initial;
+ }

--- a/blocks/locator-results/locator-results.js
+++ b/blocks/locator-results/locator-results.js
@@ -1,0 +1,686 @@
+import { loadScript, fetchPlaceholders, readBlockConfig } from '../../scripts/lib-franklin.js';
+import { getOfficeListings } from '../../scripts/esb-api-utils.js';
+import { createElement, addQueryParamToURL, getQueryParamFromURL } from '../../scripts/scripts.js';
+import { generatePaginationData, createPaginationButton } from '../../scripts/search-utils.js';
+import {
+  classes,
+  officeLocatorResultFilters,
+  officeLocatorViewOptions,
+  BING_MAPS_API_KEY,
+  BING_MAPS_BASE_URL,
+} from './utils/constants.js';
+
+const {
+  stewartOffice,
+  independentAgency,
+  locatorResultsLoadingText,
+  agenciesFound,
+  officeLocations,
+  locatorSearchErrorText,
+  tryAgainLater,
+  noLocationsFound,
+  expandSearchCriteria,
+  mailingShippingAddress,
+  underwriter,
+  serviceState,
+  details,
+} = await fetchPlaceholders();
+
+const textValues = {
+  stewartOffice: stewartOffice || 'Stewart Office',
+  independentAgency: independentAgency || 'Independent Agency',
+  resultsLoading: locatorResultsLoadingText || 'Searching through our vast network of locations...',
+  officeLocations: async (isAgencyLocator) => (isAgencyLocator ? agenciesFound || 'Agencies Found' : officeLocations || 'Office Locations'),
+  errorFetchingResults: locatorSearchErrorText || 'There was an error fetching the results.',
+  tryAgainLater: tryAgainLater || 'Please try again later.',
+  noResultsFound: noLocationsFound || 'No locations found.',
+  expandSearchCriteria: expandSearchCriteria || 'Try expanding your search criteria.',
+  mailingShippingAddress: mailingShippingAddress || 'Mailing/Shipping Address',
+  underWriter: underwriter || 'Underwriter',
+  serviceState: serviceState || 'Service State',
+  details: details || 'Details',
+  maps: {
+    map: 'Map',
+    googleMapsBaseUrl: 'https://www.google.com/maps/place',
+  },
+};
+
+let currentListings = [];
+
+/**
+ * Creates a fontawesome icon.
+ * @param {String} iconName the fontawesome icon name.
+ * @param {Array<String>} additionalClasses the classes to add to the icon.
+ * @returns an icon element.
+ */
+const renderIcon = (iconName, additionalClasses) => createElement('i', { class: ['fal', `fa-${iconName}`, ...additionalClasses || []] });
+
+/**
+ * Creates a button for the search bar view filter.
+ * @param {String} buttonName
+ * @returns {HTMLElement} the button containing the icon.
+ */
+const renderViewFilterButton = (buttonName) => createElement('button', {
+  class: ['button', 'secondary', classes.searchBarFilterButton],
+  'data-filter': buttonName,
+}, renderIcon(buttonName));
+
+/**
+ * Creates the search results container
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ * @returns {HTMLElement} the search results container.
+ */
+const renderSearchResultsContainer = (isAgencyLocator) => createElement('div', { class: classes.resultsContainer }, [
+  createElement('ul', { class: classes.resultsList }),
+  ...!isAgencyLocator ? [createElement('div', { class: classes.mapContainer })] : [],
+]);
+
+/**
+ * Creates the search bar
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ * @returns {HTMLElement} the search bar.
+ */
+const renderSearchBar = (isAgencyLocator) => createElement(
+  'div',
+  { class: [classes.searchBar, 'hide'] },
+  [
+    createElement('div', { class: 'section' }, [
+      createElement('h2', { class: classes.title }, textValues.resultsLoading),
+      createElement('h3', { class: classes.subTitle }),
+      createElement('div', { class: classes.loader }, renderIcon('spinner', ['fa-spin'])),
+      createElement('div', { class: classes.searchBarActions }, [
+        ...!isAgencyLocator ? [createElement('div', { class: classes.searchBarFilter }, Object.entries(officeLocatorResultFilters)
+          .map(
+            (filterItem) => createElement('button', { class: ['button', 'secondary', classes.searchBarFilterButton], 'data-filter': filterItem[1].id }, [
+              createElement('span', {}, filterItem[1].label),
+              createElement('span', { class: classes.searchBarFilterCount }),
+            ]),
+          ))] : [],
+        ...!isAgencyLocator ? [createElement('div', { class: classes.searchBarViewFilter }, Object
+          .entries(officeLocatorViewOptions)
+          .map((viewItem) => renderViewFilterButton(viewItem[0]))),
+        ] : [],
+        createElement('nav', { class: [classes.searchBarPagination, 'search-results-pagination', 'dark-bg'], 'aria-label': 'Search results pagination' }),
+      ]),
+    ]),
+  ],
+);
+
+/**
+ * Handles click events once a map marker is visible.
+ * Used to close the infobox when the X icon is clicked.
+ * @param {Event} e
+ */
+const handleMapMarkerInfoBoxClick = (e) => {
+  const isCloseAction = e.originalEvent.target.className === 'close-button' || e.originalEvent.target.className === 'fal fa-times';
+
+  if (isCloseAction) {
+    e.target.setOptions({ visible: false });
+  }
+};
+
+/**
+ *
+ * @param {Event} e the event.
+ * @param {Object} listing the listing data.
+ * @param {*} infobox the infobox.
+ * @param {*} map the map.
+ */
+const handleMapMarkerClick = (e, listing, infobox, map) => {
+  const shouldSetOptions = e.target.metadata && e.targetType === 'pushpin';
+
+  if (shouldSetOptions) {
+    // eslint-disable-next-line no-use-before-define
+    const listingElement = createListing(listing, false, true);
+    const closeButton = createElement('button', { class: 'close-button' }, renderIcon('times'));
+    listingElement.appendChild(closeButton);
+
+    infobox.setOptions({
+      location: e.target.getLocation(),
+      visible: true,
+      htmlContent: listingElement.outerHTML,
+    });
+
+    // eslint-disable-next-line no-undef
+    Microsoft.Maps.Events.addHandler(infobox, 'click', handleMapMarkerInfoBoxClick);
+
+    map.setView({ center: e.target.getLocation() });
+  }
+};
+
+/**
+ * populates markers on the map with the listings.
+ */
+const populateMapMarkers = () => {
+  /* eslint-disable no-undef */
+  const map = new Microsoft.Maps.Map(`.${classes.mapContainer}`, {
+    credentials: BING_MAPS_API_KEY,
+  });
+
+  const infobox = new Microsoft.Maps.Infobox(map.getCenter(), {
+    visible: false,
+  });
+
+  infobox.setMap(map);
+  const pins = [];
+
+  currentListings.forEach((listing) => {
+    const { Latitude, Longitude } = listing;
+    const isAgency = listing.AgentType === 'I';
+
+    if (Latitude && Longitude) {
+      const pinLocation = new Microsoft.Maps.Location(Latitude, Longitude);
+      pins.push(pinLocation);
+
+      const mapMarker = new Microsoft.Maps.Pushpin(pinLocation, {
+        color: isAgency ? 'purple' : 'teal',
+      });
+
+      map.setView({ center: pinLocation });
+
+      mapMarker.metadata = listing;
+
+      Microsoft.Maps.Events.addHandler(mapMarker, 'click', (e) => handleMapMarkerClick(e, listing, infobox, map));
+      map.entities.push(mapMarker);
+    }
+  });
+
+  const bounds = Microsoft.Maps.LocationRect.fromLocations(pins);
+  map.setView({ bounds });
+  map.setOptions({
+    disableScrollWheelZoom: true,
+    disableStreetside: true,
+  });
+};
+
+/**
+ * @param {Array<Object>} listings the data.
+ * @param {String} filter the filter.
+ * @returns a filtered set of listings.
+ */
+const getFilteredResults = (listings, filter) => {
+  const officeLookup = {
+    [officeLocatorResultFilters.all.id]: listings,
+    [officeLocatorResultFilters.offices.id]: listings.filter((listing) => listing.AgentType !== 'I'),
+    [officeLocatorResultFilters.agencies.id]: listings.filter((listing) => listing.AgentType === 'I'),
+  };
+
+  return officeLookup[filter];
+};
+
+const isMapView = () => getQueryParamFromURL('view') === officeLocatorViewOptions.map;
+
+/**
+ * Handles the filter click event.
+ * @param {HTMLElement} filter the filter element.
+ * @param {Array<Object>} listings the listings retrieved from the api.
+ */
+const handleFilterClick = (
+  filterButton,
+  listings,
+  searchBar,
+  searchResultsList,
+  isAgencyLocator,
+) => {
+  const { filter } = filterButton.dataset;
+  const { resultsPerPage } = searchBar.parentElement.dataset;
+
+  const allFilters = searchBar.querySelectorAll(`.${classes.searchBarFilter} button[data-filter]`);
+  [...allFilters].forEach((button) => button.classList.remove('active'));
+  filterButton.classList.add('active');
+
+  const filteredListings = getFilteredResults(listings, filter);
+  currentListings = filteredListings;
+  addQueryParamToURL('filter', filter);
+
+  // eslint-disable-next-line no-use-before-define
+  setupPaginatedResults(
+    filteredListings,
+    searchBar,
+    searchResultsList,
+    isAgencyLocator,
+    resultsPerPage,
+    true,
+  );
+
+  if (isMapView()) {
+    populateMapMarkers();
+  } else {
+    searchResultsList.scrollIntoView({ behavior: 'smooth' });
+  }
+};
+
+/**
+ *
+ * @param {HTMLElement} searchBar the searchbar element.
+ * @param {Array<Object>} listings the listings retrieved from the api.
+ * @param {HTMLElement} searchResultsList the <ul> to populate.
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ */
+const setupFilters = (searchBar, listings, searchResultsList, isAgencyLocator) => {
+  const activeFilter = getQueryParamFromURL('filter') || officeLocatorResultFilters.all.id;
+  const officeCount = listings.filter((listing) => listing.AgentType !== 'I').length;
+  const agencyCount = listings.length - officeCount;
+  const filters = searchBar.querySelectorAll(`.${classes.searchBarFilter} button[data-filter]`);
+  const activeFilterButton = searchBar.querySelector(`.${classes.searchBarFilter} button[data-filter="${activeFilter}"]`);
+  activeFilterButton.classList.add('active');
+
+  [...filters].forEach((filter) => {
+    const countElement = filter.querySelector(`.${classes.searchBarFilterCount}`);
+
+    if (filter.dataset.filter === officeLocatorResultFilters.all.id) {
+      countElement.innerText = ` (${listings.length})`;
+    } else {
+      countElement.innerText = filter.getAttribute('data-filter') === officeLocatorResultFilters.offices.id
+        ? ` (${officeCount})`
+        : ` (${agencyCount})`;
+    }
+
+    filter.addEventListener('click', () => handleFilterClick(filter, listings, searchBar, searchResultsList, isAgencyLocator));
+  });
+};
+
+/**
+ * handles the view filter click event.
+ * @param {String} filter the view filter.
+ * @param {HTMLElement} searchResultsList the <ul> to populate.
+ */
+const handleViewClick = (filter, searchResultsList) => {
+  const { filter: viewFilter } = filter.dataset;
+  addQueryParamToURL('view', viewFilter);
+
+  const viewFilters = filter.parentElement.querySelectorAll(`.${classes.searchBarViewFilter} button[data-filter]`);
+  const mapContainer = searchResultsList.parentElement.querySelector(`.${classes.mapContainer}`);
+  const pagination = searchResultsList.parentElement.parentElement.querySelector(`.${classes.searchBarPagination}`);
+
+  [...viewFilters].forEach((view) => view.classList.remove('active'));
+  filter.classList.add('active');
+
+  if (viewFilter === officeLocatorViewOptions.map) {
+    pagination.classList.add('hide');
+    mapContainer.classList.add('active');
+    searchResultsList.classList.add('hide');
+    populateMapMarkers();
+  } else {
+    pagination.classList.remove('hide');
+    mapContainer.classList.remove('active');
+    searchResultsList.classList.remove('hide');
+  }
+};
+
+/**
+ * Sets up the view filters.
+ * @param {HTMLElement} searchBar the searchbar element.
+ * @param {Array<Object>} listings the listings retrieved from the api.
+ */
+const setupViews = (searchBar, searchResultsList) => {
+  const viewFilters = searchBar.querySelectorAll(`.${classes.searchBarViewFilter} button[data-filter]`);
+  const activeViewFilter = getQueryParamFromURL('view') || officeLocatorViewOptions.list;
+  const activeViewFilterButton = searchBar.querySelector(`.${classes.searchBarViewFilter} button[data-filter="${activeViewFilter}"]`);
+  activeViewFilterButton.classList.add('active');
+  [...viewFilters].forEach((filter) => filter.addEventListener('click', () => handleViewClick(filter, searchResultsList)));
+};
+
+/**
+ *
+ * @param {Array} paginationArray
+ * @param {Number} currentPage
+ * @returns {Array} the pagination array.
+ */
+const createPagination = (paginationArray, currentPage) => paginationArray.map((page) => createPaginationButton(page, currentPage)).join('');
+
+/**
+ * Populates the data in the search bar.
+ * @param {HTMLElement} searchBar the search bar.
+ * @param {Array<Object>} listings the listings retrieved from the api.
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ * @param {HTMLElement} searchResultsList the <ul> to populate.
+ */
+const populateSearchBar = async (searchBar, listings, isAgencyLocator, searchResultsList) => {
+  const searchResultsCount = listings.length;
+  const searchResultsTitle = searchBar.querySelector(`.${classes.title}`);
+  const searchResultsSubTitle = searchBar.querySelector(`.${classes.subTitle}`);
+
+  if (!isAgencyLocator) {
+    setupFilters(searchBar, listings, searchResultsList, isAgencyLocator);
+    setupViews(searchBar, searchResultsList);
+  }
+
+  if (searchResultsCount === 0) {
+    searchResultsTitle.innerText = textValues.noResultsFound;
+    searchResultsSubTitle.innerText = textValues.expandSearchCriteria;
+    return;
+  }
+
+  searchResultsTitle.innerText = `${searchResultsCount} ${await textValues.officeLocations(isAgencyLocator)}`;
+};
+
+/**
+ *
+ * @param {Object} listing listing data.
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ * @param {Boolean} isMapPopup whether or not this is a map popup element.
+ * @returns {HTMLElement} the li element for the listing.
+ */
+const createListing = (listing, isAgencyLocator, isMapPopup) => {
+  const {
+    AgentType,
+    OfficeDisplayName,
+    OfficeAddress,
+    Fax,
+    Phone,
+    UnderwriterCode,
+    ServiceState,
+    URL,
+  } = listing;
+
+  const isIndy = AgentType === 'I';
+  const mapsLink = `${textValues.maps.googleMapsBaseUrl}/${OfficeAddress.Address1} ${OfficeAddress.Address2} ${OfficeAddress.City} ${OfficeAddress.State} ${OfficeAddress.Zip}`;
+
+  const listingItem = createElement(isMapPopup ? 'div' : 'li', { class: [classes.resultsListItem, isIndy ? 'indy' : 'stewart-office'] }, [
+    !isAgencyLocator ? createElement('div', { class: classes.listing.type }, [
+      renderIcon(isIndy ? 'male' : 'building'),
+      createElement('span', {}, isIndy ? textValues.independentAgency : textValues.stewartOffice),
+    ]) : [],
+    createElement('h4', { class: classes.listing.title }, OfficeDisplayName),
+    createElement('div', { class: classes.listing.contactInfo }, [
+      createElement('div', { class: classes.listing.address }, [
+        isAgencyLocator ? createElement('span', { class: classes.listing.addressTitle }, textValues.mailingShippingAddress) : [],
+        createElement('span', { class: `${classes.listing.address}-1` }, OfficeAddress.Address1),
+        OfficeAddress.Address2 ? createElement('span', { class: `${classes.listing.address}-2` }, OfficeAddress.Address2) : [],
+        createElement('span', { class: classes.listing.city }, `${OfficeAddress.City}, ${OfficeAddress.State} ${OfficeAddress.Zip}`),
+      ]),
+      !isAgencyLocator ? createElement('div', { class: classes.listing.phone }, [
+        createElement('span', {}, `ph. ${Phone}`),
+        ...Fax ? [createElement('span', {}, `fx. ${Fax}`)] : [],
+      ]) : [],
+    ]),
+    !isAgencyLocator && !isMapPopup ? createElement('div', { class: classes.listing.details }, [
+      createElement('a', { href: mapsLink, target: '_blank' }, [
+        renderIcon('map-marker-alt'),
+        createElement('span', {}, textValues.maps.map),
+      ]),
+      URL ? createElement('a', { href: URL, targe: '_blank' }, textValues.details) : [],
+    ]) : [],
+    isAgencyLocator ? createElement('div', { class: classes.listing.otherInfo }, [
+      createElement('span', {}, `<strong>${textValues.underWriter}</strong>: ${UnderwriterCode}`),
+      createElement('span', {}, `<strong>${textValues.serviceState}</strong>: ${ServiceState}`),
+    ]) : [],
+  ]);
+
+  return listingItem;
+};
+
+/**
+ *
+ * @param {Number} currentPage the current page.
+ * @param {Number} resultsPerPage the number of results per page.
+ * @param {Array<Object>} results the listing results.
+ * @param {HTMLElement} searchResultsList the <ul> to populate.
+ * @returns {HTMLElement} the li element for the listing.
+ */
+const createResultsPerPage = (
+  currentPage,
+  listings,
+  resultsPerPage,
+  searchResultsList,
+  isAgencyLocator,
+) => {
+  const listingSet = listings
+    .slice((currentPage - 1) * resultsPerPage, currentPage * resultsPerPage)
+    .map((listing) => createListing(listing, isAgencyLocator, false));
+
+  searchResultsList.innerHTML = '';
+  searchResultsList.append(...listingSet);
+};
+
+/**
+ *
+ * @param {Array<Object>} listings the listing data.
+ * @param {HTMLElement} searchBar the searchBar element.
+ * @param {HTMLElement} searchResultsList the <ul> to populate.
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ * @param {Number} resultsPerPage the number of results per page.
+ * @param {Boolean} isFilterClick whether or not this is a filter click.
+ */
+const setupPaginatedResults = (
+  listings,
+  searchBar,
+  searchResultsList,
+  isAgencyLocator,
+  resultsPerPage,
+  isFilterClick = false,
+) => {
+  const totalPages = Math.ceil(listings.length / resultsPerPage);
+  const hasPages = totalPages > 1;
+
+  if (isFilterClick) {
+    addQueryParamToURL('page', 1);
+  }
+
+  let currentPage = Number(getQueryParamFromURL('page')) || 1;
+  const paginationContainer = searchBar.querySelector(`.${classes.searchBarPagination}`);
+  paginationContainer.innerHTML = '';
+
+  createResultsPerPage(currentPage, listings, resultsPerPage, searchResultsList, isAgencyLocator);
+
+  if (hasPages) {
+    let paginationArray = generatePaginationData(currentPage, totalPages);
+    paginationContainer.innerHTML = createPagination(paginationArray, currentPage);
+    const paginationList = searchBar.querySelector('.search-results-pagination');
+    const paginationButtons = searchBar.querySelectorAll('.search-results-pagination-button');
+
+    paginationList.addEventListener('click', (event) => {
+      const { target } = event;
+      const shouldUpdate = (target.matches('button') || target.matches('span.fa-icon')) && target.dataset.page !== '…';
+
+      if (shouldUpdate) {
+        currentPage = target.matches('span.fa-icon') ? Number(target.parentElement.dataset.page) : Number(target.dataset.page);
+        [...paginationButtons].forEach((button) => button.classList.remove('active'));
+        paginationArray = generatePaginationData(currentPage, totalPages);
+        paginationContainer.innerHTML = createPagination(paginationArray, currentPage);
+        target.classList.add('active');
+        addQueryParamToURL('page', currentPage);
+        createResultsPerPage(
+          currentPage,
+          listings,
+          resultsPerPage,
+          searchResultsList,
+          isAgencyLocator,
+        );
+
+        searchResultsList.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
+  }
+};
+
+/**
+ * populates the search results
+ * @param {Object} params the search params.
+ * @param {Array<Object>} listings the listings retrieved from the api.
+ * @param {HTMLElement} searchResultsList the <ul> to populate.
+ * @param {HTMLElement} searchBar the search bar.
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ * @param {Number} resultsPerPage the number of results per page.
+ */
+const populateSearchResults = async (
+  params,
+  listings,
+  searchResultsList,
+  searchBar,
+  isAgencyLocator,
+  resultsPerPage,
+) => {
+  const sortedListings = listings.sort((item) => (item.AgentType !== 'I' ? -1 : 1));
+
+  if (!isAgencyLocator) {
+    await loadScript(BING_MAPS_BASE_URL);
+  }
+
+  const listingsToShow = isAgencyLocator && params.agencyName
+    ? sortedListings.filter((listing) => listing
+      .OfficeDisplayName
+      .toLowerCase()
+      .includes(params.agencyName
+        .toLowerCase()))
+      .filter((agencyListings) => agencyListings.AgentType === 'I')
+    : sortedListings;
+
+  const filteredListings = getFilteredResults(
+    listingsToShow,
+    params.filter || officeLocatorResultFilters.all.id,
+  );
+
+  currentListings = filteredListings;
+
+  const filters = searchBar.querySelectorAll(`.${classes.searchBarFilterButton}`);
+  const mapContainer = searchResultsList.parentElement.querySelector(`.${classes.mapContainer}`);
+  [...filters].forEach((filter) => filter.classList.remove('active'));
+  await populateSearchBar(searchBar, listingsToShow, isAgencyLocator, searchResultsList);
+
+  setupPaginatedResults(
+    filteredListings,
+    searchBar,
+    searchResultsList,
+    isAgencyLocator,
+    resultsPerPage,
+    false,
+  );
+
+  if (isMapView()) {
+    mapContainer.classList.add('active');
+    searchResultsList.classList.add('hide');
+
+    setTimeout(() => {
+      // there seems to be a race condition on page load,
+      // even though mapContainer is there when this is called.
+      // bing maps just takes a bit to load.
+      populateMapMarkers();
+    }, 100);
+  }
+};
+
+/**
+ * Removes the loading state on the block.
+ * @param {HTMLElement} block the block.
+ * @param {HTMLElement} searchResultsList the <ul> results list.
+ */
+const removeLoadingState = (block, searchResultsList) => {
+  block.classList.remove(classes.state.loading);
+  const pagination = block.querySelector(`.${classes.searchBarPagination}`);
+
+  if (isMapView()) {
+    pagination.classList.add('hide');
+  } else {
+    searchResultsList.classList.remove('hide');
+  }
+};
+
+/**
+ * Sets the loading state on the block.
+ * @param {HTMLElement} block the block.
+ * @param {HTMLElement} searchResultsList the <ul> results list.
+ * @param {HTMLElement} searchBar the search bar.
+ * @param {HTMLElement} searchResultsTitle the search results title.
+ * @param {HTMLElement} searchResultsSubtitle the search results subtitle.
+ */
+const setLoadingState = async (
+  block,
+  searchResultsList,
+  searchBar,
+  searchResultsTitle,
+  searchResultsSubtitle,
+  mapContainer,
+) => {
+  block.classList.add(classes.state.loading);
+  searchResultsList.innerHTML = '';
+  searchBar.classList.remove('hide');
+  searchResultsTitle.innerText = textValues.resultsLoading;
+  searchResultsSubtitle.innerText = '';
+
+  if (mapContainer) {
+    mapContainer.classList.remove('active');
+  }
+};
+
+/**
+ * Executes the search.
+ * @param {Object} params the search params.
+ * @param {HTMLElement} block the block.
+ * @param {Boolean} isAgencyLocator whether or not this is an agency locator.
+ */
+export const executeSearch = async (params, block, isAgencyLocator) => {
+  block.classList.remove(classes.state.error);
+  const searchResultsList = block.querySelector(`.${classes.resultsList}`);
+  const searchBar = block.querySelector(`.${classes.searchBar}`);
+  const searchResultsTitle = searchBar.querySelector(`.${classes.title}`);
+  const searchResultsSubtitle = searchBar.querySelector(`.${classes.subTitle}`);
+  const mapContainer = block.querySelector(`.${classes.mapContainer}`);
+  const { resultsPerPage } = block.dataset;
+
+  await setLoadingState(
+    block,
+    searchResultsList,
+    searchBar,
+    searchResultsTitle,
+    searchResultsSubtitle,
+    mapContainer,
+  );
+
+  try {
+    const listings = await getOfficeListings(params, isAgencyLocator);
+
+    await populateSearchResults(
+      params,
+      listings,
+      searchResultsList,
+      searchBar,
+      isAgencyLocator,
+      resultsPerPage,
+    );
+  } catch (e) {
+    console.log(e); // eslint-disable-line no-console
+    searchResultsTitle.innerText = textValues.errorFetchingResults;
+    searchResultsSubtitle.innerText = textValues.tryAgainLater;
+    block.classList.add(classes.state.error);
+
+    if (mapContainer) {
+      mapContainer.classList.remove('active');
+    }
+  }
+
+  removeLoadingState(block, searchResultsList);
+};
+
+/**
+ * Decorates the block.
+ * @param {HTMLElement} block
+ */
+export default async function decorate(block) {
+  const blockConfig = readBlockConfig(block);
+  block.dataset.resultsPerPage = blockConfig['results-per-page'] || 10;
+  const isAgencyLocator = block.classList.contains('agency');
+  const searchBar = renderSearchBar(isAgencyLocator);
+  const searchResultsContainer = renderSearchResultsContainer(isAgencyLocator);
+
+  block.innerHTML = '';
+  block.appendChild(searchBar);
+  block.appendChild(searchResultsContainer);
+
+  const hasSearchParams = window.location.search.includes('?');
+
+  if (hasSearchParams) {
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const allParams = Object.fromEntries(urlSearchParams.entries());
+    delete allParams.esbUser; // temp
+    delete allParams.esbPass; // temp
+
+    setTimeout(async () => {
+      searchResultsContainer.scrollIntoView({ behavior: 'smooth' });
+      // the API is slow sometimes, so we need a timeout
+      // to avoid putting the loading state on the block if it takes a few seconds
+      await executeSearch(allParams, block, isAgencyLocator);
+    }, 100);
+  }
+}

--- a/blocks/locator-results/utils/constants.js
+++ b/blocks/locator-results/utils/constants.js
@@ -1,0 +1,58 @@
+const blockName = 'locator-results';
+
+export const classes = {
+  state: {
+    loading: 'loading',
+    error: 'error',
+  },
+  searchBar: `${blockName}-search-bar`,
+  loader: `${blockName}-loading-spinner`,
+  title: `${blockName}-title`,
+  subTitle: `${blockName}-subtitle`,
+  searchBarActions: `${blockName}-actions`,
+  searchBarFilter: `${blockName}-filter`,
+  searchBarFilterCount: `${blockName}-filter-count`,
+  searchBarFilterButton: `${blockName}-filter-button`,
+  searchBarViewFilter: `${blockName}-view-filter`,
+  searchBarPagination: `${blockName}-pagination`,
+  resultsContainer: `${blockName}-list-container`,
+  resultsList: `${blockName}-list`,
+  resultsListItem: `${blockName}-list-item`,
+  mapContainer: `${blockName}-map-container`,
+  listing: {
+    type: `${blockName}-listing-type`,
+    title: `${blockName}-listing-title`,
+    contactInfo: `${blockName}-listing-contact-info`,
+    details: `${blockName}-listing-details`,
+    address: `${blockName}-listing-address`,
+    addressTitle: `${blockName}-listing-address-title`,
+    city: `${blockName}-listing-city`,
+    phone: `${blockName}-listing-phone`,
+    viewOnMap: `${blockName}-listing-view-on-map`,
+    viewDetails: `${blockName}-listing-view-details`,
+    otherInfo: `${blockName}-listing-other-info`,
+  },
+};
+
+export const officeLocatorResultFilters = {
+  all: {
+    id: 'all',
+    label: 'All',
+  },
+  offices: {
+    id: 'offices',
+    label: 'Stewart Offices',
+  },
+  agencies: {
+    id: 'agencies',
+    label: 'Independent Agencies',
+  },
+};
+
+export const officeLocatorViewOptions = {
+  list: 'list',
+  map: 'map',
+};
+
+export const BING_MAPS_API_KEY = 'AiZTZg5KCzz6j4GXFWdqSbmhcnKD08BUT11H1Kr20aLFaQYr7iSx30hiZOEDPq-T';
+export const BING_MAPS_BASE_URL = 'https://www.bing.com/maps/sdkrelease/mapcontrol';

--- a/blocks/locator/locator.css
+++ b/blocks/locator/locator.css
@@ -1,0 +1,117 @@
+main .locator {
+  background-color: var(--clr-gray);
+  border: 1px solid var(--clr-gray-dark);
+  box-shadow: 0 5px 4px -2px rgb(0 0 0 / 15%);
+  padding: 1rem;
+  margin-block-end: 2rem;
+}
+
+main .locator .locator-form {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  width: 100%;
+  font-weight: 600;
+}
+
+main .locator .locator-form .form-field-pair {
+  flex-basis: 100%;
+  position: relative;
+}
+
+main .locator .locator-form input[type="text"],
+main .locator .locator-form input[type="number"] {
+  font-family: var(--body-font-family);
+  margin-block-end: 1rem;
+  border: 1px solid #6e6e6e;
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--clr-black);
+  height: 50px;
+  padding: 0 1rem;
+  max-width: initial;
+  font-size: 1rem;
+}
+
+main .locator .locator-form select {
+  font-family: var(--body-font-family);
+  margin-block-end: 1rem;
+  display: block;
+  width: 100%;
+  height: 50px;
+  appearance: none;
+  background-color: var(--clr-white);
+  padding-left: 1rem;
+  font-size: 1rem;
+}
+
+main .locator .locator-form .error {
+  font-size: 0.85rem;
+  color: var(--clr-danger);
+  flex-basis: 100%;
+  text-align: left;
+}
+
+main .locator .locator-form .form-field-pair.select::after {
+  content: "";
+  position: absolute;
+  right: 10px;
+  top: 1.125rem;
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 10px solid var(--clr-primary);
+}
+
+main .locator button[type="submit"] {
+  font-size: 1.125rem;
+  font-weight: normal;
+  width: 100%;
+  padding: 1rem 0;
+  font-family: var(--body-font-family);
+}
+
+main .locator.office .form-field-pair .locator-autocomplete-list {
+  position: absolute;
+  background-color: var(--clr-white);
+  border: 1px solid var(--clr-black);
+  list-style: none;
+  z-index: 2;
+  bottom: 70px;
+  left: 0;
+  right: 0;
+  font-size: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+main .locator.office .form-field-pair .locator-autocomplete-list li {
+  padding: 10px;
+  cursor: pointer;
+  background-color: var(--clr-white);
+  border-bottom: 1px solid var(--clr-gray-light);
+}
+
+main .locator.office .form-field-pair .locator-autocomplete-list li:hover,
+main .locator.office .form-field-pair .locator-autocomplete-list li.active {
+  background-color: var(--clr-cyan);
+}
+
+@media (min-width: 900px) {
+  main .locator {
+    padding: 3.4375rem;
+  }
+
+  main .locator .locator-form .form-field-pair.half {
+    flex-basis: 49.5%;
+    margin-block-end: 0;
+  }
+
+  main .locator button[type="submit"] {
+    margin-top: 1rem;
+    font-size: 1.5rem;
+    font-weight: 600;
+    width: initial;
+  }
+}

--- a/blocks/locator/locator.js
+++ b/blocks/locator/locator.js
@@ -1,0 +1,454 @@
+import {
+  createElement,
+  debounce,
+  addQueryParamToURL,
+  getQueryParamFromURL,
+} from '../../scripts/scripts.js';
+import { getTaxonomyCategory } from '../../scripts/taxonomy.js';
+import { fetchPlaceholders } from '../../scripts/lib-franklin.js';
+import { getAutoCompleteSuggestions } from '../../scripts/esb-api-utils.js';
+import { executeSearch } from '../locator-results/locator-results.js';
+
+const blockName = 'locator';
+
+let AUTOCOMPLETE_ACTIVE_INDEX = -1;
+
+const placeholders = await fetchPlaceholders();
+
+const {
+  agencyName,
+  findYourAgency,
+  findUs,
+  findAnAgency,
+  findAnOffice,
+  locateOfficeResultsPage,
+  locateAgencyResultsPage,
+  cityOrAgencyNameError,
+} = placeholders;
+
+const classes = {
+  locatorResults: `${blockName}-results`,
+  autoCompleteList: `${blockName}-autocomplete-list`,
+  autoCompleteListItem: `${blockName}-autocomplete-list-item`,
+};
+
+const selectors = {
+  locator: `.${blockName}`,
+  locatorResults: `.${classes.locatorResults}`,
+  agencyLocator: {
+    agencyName: `.${blockName}.agency #input-agency-name`,
+  },
+  officeLocator: {
+    autoCompleteList: `.${blockName}.office .${classes.autoCompleteList}`,
+    addressInput: `.${blockName}.office #input-address`,
+  },
+  sharedInputs: {
+    cityInput: `.${blockName} #input-city`,
+    stateInput: `.${blockName} #input-state`,
+  },
+};
+
+const defaultValues = {
+  agencyName: agencyName || 'Agency Name',
+  address: placeholders.address || 'Address',
+  city: placeholders.city || 'City',
+  state: placeholders.state || 'State',
+  zipcode: placeholders.zipCode || 'Zip Code',
+  serviceState: placeholders.serviceState || 'Service State',
+  distance: placeholders.distance || 'Distance',
+  formTitle: (isAgencyLocator) => `Find an ${isAgencyLocator ? 'Agency' : 'Office'}`,
+  submitButtonText: (isAgencyLocator) => `Find an ${isAgencyLocator ? 'Agency' : 'Office'}`,
+  formAction: (isAgencyLocator) => (isAgencyLocator ? '/en/agency-verification' : '/en/locate-an-office'),
+  agencyValidationError: cityOrAgencyNameError || 'Please enter a city or agency name.',
+};
+
+/**
+ * Creates an option element for a select field
+ * @param {Object} option
+ * @returns {HTMLElement} an option element
+ */
+const createSelectOption = (option) => {
+  const stateAbbr = Object.values(option).find((key) => (typeof key === 'object' && key.title));
+  const value = stateAbbr && stateAbbr.title ? stateAbbr.title : option.name;
+
+  const selectOption = createElement(
+    'option',
+    {
+      value: value.split('-')[0],
+      ...option.disabled ? { disabled: true } : {},
+      ...option.selected ? { selected: true } : {},
+    },
+    option.title,
+  );
+
+  return selectOption;
+};
+
+/**
+ * Creates a a form field pair (label and form field)
+ * @param {Object} fieldOptions
+ * @returns {HTMLElement} a div containing a label and a form field
+ */
+const createFormField = (fieldOptions) => {
+  const { attributes, selectOptions, width } = fieldOptions;
+  const {
+    id,
+    type,
+    placeholder,
+    value,
+  } = attributes;
+
+  if (selectOptions) {
+    const defaultOptionAttributes = {
+      name: '',
+      disabled: true,
+      selected: true,
+      title: `Select a ${placeholder}`,
+    };
+
+    selectOptions.unshift(defaultOptionAttributes);
+  }
+
+  const formFieldTag = type === 'select' ? 'select' : 'input';
+
+  const formFieldPair = createElement('div', { class: ['form-field-pair', width || 'full', type] }, [
+    createElement('label', {
+      for: id,
+    }),
+    createElement(formFieldTag, attributes, type === 'select' && selectOptions ? selectOptions.map((option) => createSelectOption(option)) : null),
+  ]);
+
+  if (type === 'select' && value) {
+    formFieldPair.querySelector('select').value = value;
+  }
+
+  return formFieldPair;
+};
+
+/**
+ * Creates a locator form for the agency locator or office locator based on some parameters.
+ * @param {Object} locator parameters
+ * @returns {HTMLElement} a div containing a full form.
+ */
+const createLocatorForm = ({
+  formAction,
+  type,
+  formFields,
+  submitButtonText,
+  title,
+}) => createElement('form', {
+  class: [`${type}-locator-form`, 'locator-form'],
+  action: formAction,
+  autocomplete: 'off',
+}, [
+  createElement('h4', {}, title),
+  ...formFields,
+  createElement('button', {
+    type: 'submit',
+  }, submitButtonText),
+]);
+
+/**
+ * @param {Boolean} isAgencyLocator whether the locator is an agency locator
+ * returns {Array} an array of form fields
+ */
+const getLocatorFormFields = async (isAgencyLocator) => {
+  const states = await getTaxonomyCategory('States');
+  const distances = await getTaxonomyCategory('Distance');
+  const stateOptions = Object.values(states).filter((state) => state.title);
+  const serviceStateOptions = JSON.parse(JSON.stringify(stateOptions));
+  const distanceOptions = Object.values(distances).filter((distance) => distance.title);
+
+  const formFields = [
+    ...(isAgencyLocator ? [createFormField({
+      attributes: {
+        'aria-label': 'Agency Name',
+        id: 'input-agency-name',
+        name: 'agencyName',
+        type: 'text',
+        placeholder: defaultValues.agencyName,
+        value: getQueryParamFromURL('agencyName') || '',
+      },
+    })] : []),
+    ...(!isAgencyLocator ? [createFormField({
+      attributes: {
+        'aria-label': 'Address',
+        id: 'input-address',
+        name: 'address',
+        type: 'text',
+        placeholder: defaultValues.address,
+        value: getQueryParamFromURL('address') || '',
+        'aria-owns': 'autocomplete-list',
+        'aria-expanded': false,
+      },
+    })] : []),
+    createFormField({
+      attributes: {
+        'aria-label': 'City',
+        id: 'input-city',
+        name: 'city',
+        type: 'text',
+        placeholder: defaultValues.city,
+        value: getQueryParamFromURL('city') || '',
+      },
+    }),
+    createFormField({
+      attributes: {
+        'aria-label': 'State',
+        id: 'input-state',
+        name: 'state',
+        type: 'select',
+        ...!isAgencyLocator ? { required: true } : {},
+        placeholder: defaultValues.state,
+        value: getQueryParamFromURL('state') || '',
+      },
+      selectOptions: stateOptions,
+      width: 'half',
+    }),
+    ...(isAgencyLocator ? [createFormField({
+      attributes: {
+        'aria-label': 'Zip Code',
+        id: 'input-zipcode',
+        name: 'zip',
+        type: 'number',
+        placeholder: defaultValues.zipcode,
+        pattern: '[0-9]{5}',
+        value: getQueryParamFromURL('zip') || '',
+      },
+      width: 'half',
+    })] : []),
+    ...(isAgencyLocator ? [createFormField({
+      attributes: {
+        'aria-label': 'Service State',
+        id: 'input-service-state',
+        name: 'serviceState',
+        type: 'select',
+        placeholder: defaultValues.serviceState,
+        value: getQueryParamFromURL('serviceState') || '',
+      },
+      selectOptions: serviceStateOptions,
+    })] : []),
+    ...(!isAgencyLocator ? [createFormField({
+      attributes: {
+        'aria-label': 'Distance',
+        id: 'input-distance',
+        name: 'distance',
+        type: 'select',
+        placeholder: defaultValues.distance,
+        value: getQueryParamFromURL('distance') || '',
+      },
+      selectOptions: distanceOptions,
+      width: 'half',
+    })] : []),
+  ];
+
+  return formFields;
+};
+
+/**
+ *
+ * @param {String} city the city
+ * @param {String} state the state
+ * @param {HTMLElement} block the locator block
+ * @param {HTMLElement} autoCompleteList the autocomplete list
+ */
+const handleSuggestionclick = (city, state, text, block, autoCompleteList) => {
+  const cityInput = block.querySelector(selectors.sharedInputs.cityInput);
+  const stateInput = block.querySelector(selectors.sharedInputs.stateInput);
+  const addressInput = block.querySelector(selectors.officeLocator.addressInput);
+  cityInput.value = city;
+  stateInput.value = state;
+
+  if (addressInput) {
+    addressInput.value = text;
+  }
+  autoCompleteList.remove();
+};
+
+/**
+ * @param {Object<Array>} suggestions an array of suggestions
+ * @param {HTMLElement} block the locator block
+ * @param {HTMLElement} addressInput the address input
+ * Creates an autocomplete list box.
+ */
+const createAutoCompleteList = (suggestions, block, addressInput) => {
+  const autoCompleteList = createElement('ul', {
+    class: classes.autoCompleteList,
+    id: 'autocomplete-list',
+    role: 'listbox',
+    tabindex: 0,
+  });
+
+  suggestions.forEach((suggestion) => {
+    const { city, state, text } = suggestion;
+    const listItem = createElement('li', {
+      class: classes.autoCompleteListItem,
+      'data-city': city,
+      'data-state': state,
+    }, text);
+    autoCompleteList.appendChild(listItem);
+    listItem.addEventListener('click', () => handleSuggestionclick(city, state, text, block, autoCompleteList));
+  });
+
+  addressInput.setAttribute('aria-expanded', true);
+  const fieldContainer = addressInput.parentElement;
+  fieldContainer.prepend(autoCompleteList);
+};
+
+/**
+ * Gets suggestions for the address field.
+ * @param {String} value
+ * @param {HTMLElement} block the locator block
+ */
+const getSuggestions = async (value, block) => {
+  const { address } = await getAutoCompleteSuggestions(value);
+  const existingAutoCompleteList = block.querySelector(selectors.officeLocator.autoCompleteList);
+  const addressInput = block.querySelector(selectors.officeLocator.addressInput);
+
+  if (existingAutoCompleteList) {
+    existingAutoCompleteList.remove();
+    addressInput.setAttribute('aria-expanded', false);
+  }
+
+  if (address && address.suggestions && value.length) {
+    createAutoCompleteList(address.suggestions, block, addressInput);
+  }
+};
+
+/**
+ * @param {Number} index the index of the active item
+ * @param {HTMLElement} autoCompleteList the autocomplete list
+ * Applies the active index to an autocomplete list item.
+ */
+const applyActiveIndex = (index, autoCompleteList) => {
+  [...autoCompleteList.children].forEach((item) => {
+    if (item.classList.contains('active')) {
+      item.classList.remove('active');
+    }
+  });
+
+  [...autoCompleteList.children][index].classList.add('active');
+};
+
+/**
+ * @param {Event} e the event
+ * @param {HTMLElement} block the locator block
+ * Handle keydown events on the address input
+ */
+const handleKeyDown = (e, block) => {
+  const autoCompleteList = block.querySelector(selectors.officeLocator.autoCompleteList);
+
+  if (autoCompleteList) {
+    const { length } = autoCompleteList.children;
+    const { key } = e;
+
+    if (autoCompleteList) {
+      if (key === 'ArrowDown') {
+        AUTOCOMPLETE_ACTIVE_INDEX = (AUTOCOMPLETE_ACTIVE_INDEX + 1) % length;
+        applyActiveIndex(AUTOCOMPLETE_ACTIVE_INDEX, autoCompleteList);
+      } else if (key === 'ArrowUp') {
+        if (AUTOCOMPLETE_ACTIVE_INDEX === -1) {
+          AUTOCOMPLETE_ACTIVE_INDEX = 0;
+        }
+
+        AUTOCOMPLETE_ACTIVE_INDEX = (length + (AUTOCOMPLETE_ACTIVE_INDEX - 1)) % length;
+        applyActiveIndex(AUTOCOMPLETE_ACTIVE_INDEX, autoCompleteList);
+      } else if (key === 'Enter') {
+        e.preventDefault();
+        const activeItem = [...autoCompleteList.children][AUTOCOMPLETE_ACTIVE_INDEX];
+        const address = activeItem.innerText;
+        const { city, state } = activeItem.dataset;
+        handleSuggestionclick(city, state, address, block, autoCompleteList);
+        autoCompleteList.remove();
+      }
+    }
+  }
+};
+
+/**
+ * Adds event listeners for form elements.
+ * @param {Boolean} isAgencyLocator
+ * @param {Boolean} isOnResultsPage
+ * @param {HTMLElement} block the locator block
+ * @param {HTMLElement} locatorForm the locator form
+ */
+const addEventListeners = (isAgencyLocator, isOnResultsPage, block, locatorForm) => {
+  if (!isAgencyLocator) {
+    const addressInput = block.querySelector(selectors.officeLocator.addressInput);
+    const onAddressInputChange = debounce(getSuggestions);
+    addressInput.addEventListener('input', (e) => onAddressInputChange(e.target.value, block));
+    addressInput.addEventListener('keydown', (e) => handleKeyDown(e, block));
+  }
+
+  locatorForm.addEventListener('submit', async (e) => {
+    if (isAgencyLocator) {
+      const cityInput = block.querySelector(selectors.sharedInputs.cityInput);
+      const agencyNameInput = block.querySelector(selectors.agencyLocator.agencyName);
+      const error = locatorForm.querySelector('.error');
+      if (error) error.remove();
+
+      if (!cityInput.value && !agencyNameInput.value) {
+        e.preventDefault();
+        const errorElement = createElement('div', { class: 'error' }, defaultValues.agencyValidationError);
+        locatorForm.appendChild(errorElement);
+
+        return;
+      }
+    }
+
+    if (isOnResultsPage) {
+      e.preventDefault();
+      const formData = new FormData(locatorForm);
+      const urlParams = new URLSearchParams(formData);
+      window.history.pushState('name', '', window.location.pathname);
+
+      urlParams.forEach((value, key) => {
+        addQueryParamToURL(key, value);
+      });
+
+      const params = Object.fromEntries(urlParams.entries());
+      const locatorResultsBlock = document.querySelector(selectors.locatorResults);
+      locatorResultsBlock.scrollIntoView({ behavior: 'smooth' });
+      await executeSearch(params, locatorResultsBlock, isAgencyLocator);
+    }
+  });
+
+  locatorForm.addEventListener('formdata', (e) => {
+    const { formData } = e;
+    const entries = [...formData.entries()];
+
+    entries.forEach((entry) => {
+      const [name, value] = entry;
+      if (value === '') formData.delete(name);
+    });
+  });
+};
+
+/**
+ * Decorates the block.
+ */
+export default async function decorate(block) {
+  const isAgencyLocator = block.classList.contains('agency');
+  const locatorType = isAgencyLocator ? 'agency' : 'office';
+  const isOnResultsPage = !!document.querySelector(`.${classes.locatorResults}.${locatorType}`);
+  const formFields = await getLocatorFormFields(isAgencyLocator);
+  const defaultSubmitButtonText = defaultValues.submitButtonText(isAgencyLocator);
+  const defaultTitle = defaultValues.formTitle(isAgencyLocator);
+  const defaultFormAction = defaultValues.formAction(isAgencyLocator);
+
+  const locatorForm = createLocatorForm({
+    formAction: (isAgencyLocator
+      ? locateAgencyResultsPage
+      : locateOfficeResultsPage
+    ) || defaultFormAction,
+    isAgencyLocator,
+    formFields,
+    type: locatorType,
+    title: (isAgencyLocator ? findYourAgency : findUs) || defaultTitle,
+    submitButtonText: (isAgencyLocator ? findAnAgency : findAnOffice) || defaultSubmitButtonText,
+  });
+
+  block.innerHTML = '';
+  block.appendChild(locatorForm);
+  addEventListeners(isAgencyLocator, isOnResultsPage, block, locatorForm);
+}

--- a/blocks/search-results/search-results.css
+++ b/blocks/search-results/search-results.css
@@ -59,49 +59,6 @@ main .search-results .search-results-nav {
   justify-content: center;
 }
 
-main .search-results .search-results-pagination {
-  display: flex;
-  align-items: center;
-  padding: 0;
-}
-
-main .search-results .search-results-pagination .search-results-pagination-item {
-  display: inline-block;
-  margin: 0 0.125rem;
-}
-
-main .search-results .search-results-pagination .search-results-pagination-item > button {
-  background: none;
-  border: 0;
-  color: var(--clr-teal);
-  padding: 0.25rem 0.75rem;
-  font-size: var(--body-font-size-m);
-  font-family: var(--body-font-family);
-  font-weight: normal;
-  min-width: initial;
-  margin-block-end: 0;
-}
-
-main .search-results .search-results-pagination .search-results-pagination-item > button.arrow {
-  border: 2px solid var(--clr-teal);
-}
-
-main .search-results .search-results-pagination .search-results-pagination-item > button.active {
-  font-weight: bold;
-}
-
-
-@media (min-width: 900px) {
-  main .search-results .search-results-pagination .search-results-pagination-item > button {
-    font-size: var(--body-font-size-xl);
-    padding: 0.5rem 1rem;
-  }
-
-  main .search-results .search-results-pagination .search-results-pagination-item {
-    margin: 0 0.5rem;
-  }
-}
-
 /* tag facets */
 main .search-results .search-results-filter-container {
   display: none;

--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -1,8 +1,14 @@
-import { createSearchForm, getSearchConfig, queryIndexPath } from '../../scripts/search-utils.js';
+import {
+  createSearchForm,
+  getSearchConfig,
+  queryIndexPath,
+  generatePaginationData,
+  createPaginationButton,
+} from '../../scripts/search-utils.js';
 import ffetch from '../../scripts/ffetch.js';
-import { createElement } from '../../scripts/scripts.js';
+import { createElement, addQueryParamToURL, getQueryParamFromURL } from '../../scripts/scripts.js';
 import { toClassName, sampleRUM, fetchPlaceholders } from '../../scripts/lib-franklin.js';
-import getTaxonomy from '../../scripts/taxonomy.js';
+import { getTaxonomy } from '../../scripts/taxonomy.js';
 
 // media query match that indicates mobile/tablet width
 const isDesktop = window.matchMedia('(min-width: 900px)');
@@ -25,113 +31,14 @@ const placeholders = await fetchPlaceholders();
 const {
   filterBy,
   contentTypes,
-  nextPage,
-  previousPage,
   searchResultsPagination,
   resultsFound,
 } = placeholders;
-
-const generatePaginationData = (currentPage, totalPages) => {
-  if (!currentPage || !totalPages) {
-    return null;
-  }
-
-  const prev = currentPage === 1 ? null : currentPage - 1;
-  const next = currentPage === totalPages ? null : currentPage + 1;
-  const items = [1];
-
-  if (currentPage === 1 && totalPages === 1) {
-    return items;
-  }
-
-  if (currentPage > 3) {
-    items.push('…');
-  }
-
-  const pageOffset = 1;
-  const offsetLeft = currentPage - pageOffset;
-  const offsetRight = currentPage + pageOffset;
-
-  for (let i = offsetLeft > 2 ? offsetLeft : 2; i <= Math.min(totalPages, offsetRight); i += 1) {
-    items.push(i);
-  }
-
-  if (offsetRight + 1 < totalPages) {
-    items.push('…');
-  }
-
-  if (offsetRight < totalPages) {
-    items.push(totalPages);
-  }
-
-  if (next) {
-    items.push('>');
-  }
-
-  if (prev) {
-    items.unshift('<');
-  }
-
-  return items;
-};
-
-const addQueryParamToURL = (key, value) => {
-  const url = new URL(window.location.href);
-  url.searchParams.set(key, value);
-  window.history.pushState({}, '', url.toString());
-};
-
-const getQueryParamFromURL = (key) => {
-  const url = new URL(window.location.href);
-  return url.searchParams.get(key) || '';
-};
 
 const setupSearchForm = async (block) => {
   block.append(await createSearchForm({ type: 'default' }));
   const searchInput = block.querySelector('.search-form input[type="search"]');
   searchInput.value = getQueryParamFromURL('q') || '';
-};
-
-const createPaginationButton = (page, currentPage) => {
-  const pageLookup = {
-    '>': {
-      value: currentPage + 1,
-      text: '<span class="fa-icon far fa-chevron-right"></span>',
-      cssClass: 'arrow',
-      ariaLabel: nextPage || 'Next page',
-    },
-    '<': {
-      cssClass: 'arrow',
-      value: currentPage - 1,
-      text: '<span class="fa-icon far fa-chevron-left"></span>',
-      ariaLabel: previousPage || 'Previous page',
-    },
-    default: {
-      cssClass: '',
-      value: page,
-      text: page,
-      ariaLabel: `${placeholders.page || 'Page'} ${page}`,
-    },
-  };
-
-  const item = pageLookup[page] || pageLookup.default;
-
-  const {
-    value,
-    text,
-    cssClass,
-    ariaLabel,
-  } = item;
-
-  const isActive = currentPage === page;
-
-  const markup = `<li class="${classNames.searchResultsPaginationItem}">
-    <button class="${classNames.searchResultsPaginationButton} ${isActive ? 'active' : ''} ${cssClass}" data-page="${value}" aria-label="Go to ${ariaLabel}" ${isActive ? 'aria-current="page" aria-selected="true"' : ''} role="button">
-      ${text}
-    </button>
-  </li>`;
-
-  return markup;
 };
 
 const createResultItem = (entry) => {

--- a/fonts/fa-pro/fa.css
+++ b/fonts/fa-pro/fa.css
@@ -9291,3 +9291,19 @@
 .fa-zhihu:before {
   content: "\f63f"
 }
+
+.fa-spin {
+  animation: fa-spin 2s linear infinite;
+}
+
+@keyframes fa-spin {
+  0% {
+      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg)
+  }
+
+  to {
+      -webkit-transform: rotate(1turn);
+      transform: rotate(1turn)
+  }
+}

--- a/scripts/esb-api-utils.js
+++ b/scripts/esb-api-utils.js
@@ -1,0 +1,50 @@
+const ESB_BASE_URL = 'https://esb.stewart.com/api';
+const urlSearchParams = new URLSearchParams(window.location.search);
+const ESB_BASIC_AUTH_USER = urlSearchParams.get('esbUser'); // temp
+const ESB_BASIC_AUTH_PASS = urlSearchParams.get('esbPass'); // temp
+const ESB_AUTH_CREDENTIALS = `${ESB_BASIC_AUTH_USER}:${ESB_BASIC_AUTH_PASS}`;
+
+const headers = new Headers();
+headers.set('Authorization', `Basic ${btoa(ESB_AUTH_CREDENTIALS)}`);
+
+const getAutoCompleteSuggestions = async (prefix) => {
+  const url = `${ESB_BASE_URL}/Autocomplete?prefix=${prefix}`;
+  const suggestions = await fetch(url, {
+    method: 'GET',
+    headers,
+  });
+
+  const { autoCompleteResponse } = await suggestions.json();
+  return autoCompleteResponse;
+};
+
+const getOfficeListings = async (params, isAgencyLocator) => {
+  const url = `${ESB_BASE_URL}/Office/Listings/v2?${new URLSearchParams({
+    ...params,
+    ...!isAgencyLocator ? { isRadiusSearch: true } : {},
+    limit: 1000,
+    agent_type: isAgencyLocator ? ['I'] : ['I', 'E1', 'E2', 'S1', 'S2'],
+    office_visibility: '[both]',
+  })}`;
+
+  let results = null;
+
+  try {
+    const listings = await fetch(url, {
+      method: 'GET',
+      headers,
+    });
+
+    const { StewartOffices: { StewartOffice } } = await listings.json();
+    results = StewartOffice;
+  } catch (e) {
+    console.log(e); // eslint-disable-line no-console
+  }
+
+  return results;
+};
+
+export {
+  getOfficeListings,
+  getAutoCompleteSuggestions,
+};

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -499,6 +499,38 @@ async function loadFonts() {
 }
 
 /**
+ * Adds a parameter to the URL.
+ * @param {String} key
+ * @param {String} value
+ */
+export function addQueryParamToURL(key, value) {
+  const url = new URL(window.location.href);
+  url.searchParams.set(key, value);
+  window.history.pushState({}, '', url.toString());
+}
+
+/**
+ * Gets a query param from the URL.
+ * @param {String} key
+ * @returns {String} the value of the query parameter
+ */
+export function getQueryParamFromURL(key) {
+  const url = new URL(window.location.href);
+  return url.searchParams.get(key) || '';
+}
+
+/**
+ * Generic debounce function
+ */
+export const debounce = (func, timeout = 300) => {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => { func.apply(this, args); }, timeout);
+  };
+};
+
+/**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
  */

--- a/scripts/search-utils.js
+++ b/scripts/search-utils.js
@@ -1,6 +1,8 @@
 import { createElement, fetchNavigationHTML } from './scripts.js';
 import { fetchPlaceholders, readBlockConfig } from './lib-franklin.js';
 
+const placeholders = await fetchPlaceholders();
+
 const getSearchFormAction = async () => {
   const navHTML = await fetchNavigationHTML();
   const navElement = document.createElement('nav');
@@ -48,10 +50,95 @@ export const getSearchConfig = (block) => {
   return cfg;
 };
 
+export const createPaginationButton = (page, currentPage) => {
+  const pageLookup = {
+    '>': {
+      value: currentPage + 1,
+      text: '<span class="fa-icon far fa-chevron-right"></span>',
+      cssClass: 'arrow',
+      ariaLabel: placeholders.nextPage || 'Next page',
+    },
+    '<': {
+      cssClass: 'arrow',
+      value: currentPage - 1,
+      text: '<span class="fa-icon far fa-chevron-left"></span>',
+      ariaLabel: placeholders.previousPage || 'Previous page',
+    },
+    default: {
+      cssClass: '',
+      value: page,
+      text: page,
+      ariaLabel: `Page ${page}`,
+    },
+  };
+
+  const item = pageLookup[page] || pageLookup.default;
+
+  const {
+    value,
+    text,
+    cssClass,
+    ariaLabel,
+  } = item;
+
+  const isActive = currentPage === page;
+
+  const markup = `<li class="search-results-pagination-item">
+    <button class="search-results-pagination-button ${isActive ? 'active' : ''} ${cssClass}" data-page="${value}" aria-label="Go to ${ariaLabel}" ${isActive ? 'aria-current="page" aria-selected="true"' : ''} role="button">
+      ${text}
+    </button>
+  </li>`;
+
+  return markup;
+};
+
+export const generatePaginationData = (currentPage, totalPages) => {
+  if (!currentPage || !totalPages) {
+    return null;
+  }
+
+  const prev = currentPage === 1 ? null : currentPage - 1;
+  const next = currentPage === totalPages ? null : currentPage + 1;
+  const items = [1];
+
+  if (currentPage === 1 && totalPages === 1) {
+    return items;
+  }
+
+  if (currentPage > 3) {
+    items.push('…');
+  }
+
+  const pageOffset = 1;
+  const offsetLeft = currentPage - pageOffset;
+  const offsetRight = currentPage + pageOffset;
+
+  for (let i = offsetLeft > 2 ? offsetLeft : 2; i <= Math.min(totalPages, offsetRight); i += 1) {
+    items.push(i);
+  }
+
+  if (offsetRight + 1 < totalPages) {
+    items.push('…');
+  }
+
+  if (offsetRight < totalPages) {
+    items.push(totalPages);
+  }
+
+  if (next) {
+    items.push('>');
+  }
+
+  if (prev) {
+    items.unshift('<');
+  }
+
+  return items;
+};
+
 export const createSearchForm = async ({ type }) => {
   const searchFormAction = await getSearchFormAction();
   const formAction = new URL(searchFormAction).pathname;
-  const placeholders = await fetchPlaceholders();
   const { searchButtonText, searchFieldPlaceholder } = placeholders;
 
   const buttonHTML = {

--- a/scripts/taxonomy.js
+++ b/scripts/taxonomy.js
@@ -69,10 +69,32 @@ function fetchTaxonomy() {
   return taxonomyPromise;
 }
 
+const getDeepNestedObject = (obj, filter) => Object.entries(obj)
+  .reduce((acc, [key, value]) => {
+    let result = [];
+    if (key === filter) {
+      result = acc.concat(value);
+    } else if (typeof value === 'object') {
+      result = acc.concat(getDeepNestedObject(value, filter));
+    } else {
+      result = acc;
+    }
+    return result;
+  }, []);
+
 /**
  * Get the taxonomy a a hierarchical json object
  * @returns {Promise} the taxonomy
  */
-export default function getTaxonomy() {
+export function getTaxonomy() {
   return fetchTaxonomy();
 }
+
+/**
+ * Returns a taxonomy category as an array of objects
+ * @param {*} category
+ */
+export const getTaxonomyCategory = async (category) => {
+  const taxonomy = await getTaxonomy();
+  return getDeepNestedObject(taxonomy, category)[0];
+};

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -39,6 +39,7 @@
   --clr-gray-dark: #757575;
   --clr-teal: #006781;
   --clr-teal-light: #248464;
+  --clr-green: #0f5132;
   --clr-teal-dark: #002f39;
   --clr-purple: #53469c;
   --clr-cyan: #96e0ff;
@@ -423,10 +424,6 @@ main .section {
   margin-block-end: 2rem;
 }
 
-/* main .section.centered {
-  text-align: center;
-} */
-
 @media (min-width: 900px) {
   main .section {
     padding-inline: 6rem;
@@ -563,6 +560,8 @@ main .section>div {
 }
 
 .section.teal {
+  --text-color: var(--clr-white);
+
   background: linear-gradient(180deg, var(--clr-teal), var(--clr-teal-dark));
   box-shadow: 0 4px 4px 0 rgba(0 0 0 / 25%);
   color: var(--clr-white);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -39,9 +39,10 @@
   --clr-gray-dark: #757575;
   --clr-teal: #006781;
   --clr-teal-light: #248464;
-  --clr-green: #0f5132;
+  --clr-teal-dark: #002f39;
   --clr-purple: #53469c;
   --clr-cyan: #96e0ff;
+  --clr-danger: #dc3545;
   
 
   /* element colors */
@@ -298,6 +299,7 @@ button {
   text-align: center;
   font-size: 0.875rem;
   font-style: normal;
+  font-family: var(--body-font-family);
   font-weight: 600;
   cursor: pointer;
   color: var(--clr-white);
@@ -338,8 +340,9 @@ button:disabled:hover {
 }
 
 a.button.secondary,
-a.button.tertiary  {
-  color: currentcolor;
+a.button.tertiary,
+button.secondary,
+button.tertiary {
   background-color: transparent;
   border: 3px solid currentcolor;
 }
@@ -419,6 +422,10 @@ main .section {
   padding-inline: 1.5rem;
   margin-block-end: 2rem;
 }
+
+/* main .section.centered {
+  text-align: center;
+} */
 
 @media (min-width: 900px) {
   main .section {
@@ -556,9 +563,7 @@ main .section>div {
 }
 
 .section.teal {
-  --text-color: var(--clr-white);
-
-  background: linear-gradient(180deg, var(--clr-teal), #002f39);
+  background: linear-gradient(180deg, var(--clr-teal), var(--clr-teal-dark));
   box-shadow: 0 4px 4px 0 rgba(0 0 0 / 25%);
   color: var(--clr-white);
 }
@@ -675,4 +680,66 @@ main .section>div {
   background: var(--clr-white);
   border: 1px solid #6e6e6e;
   border-left: 0;
+}
+
+/**
+  Global styles for pagination
+**/
+main .search-results-pagination {
+  display: flex;
+  align-items: center;
+  padding: 0;
+}
+
+main .search-results-pagination .search-results-pagination-item {
+  display: inline-block;
+  margin: 0 0.125rem;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+main .search-results-pagination .search-results-pagination-item > button {
+  background: none;
+  border: 0;
+  color: var(--clr-teal);
+  padding: 0.25rem 0.75rem;
+  font-size: var(--body-font-size-m);
+  font-family: var(--body-font-family);
+  font-weight: normal;
+  min-width: initial;
+  margin-block-end: 0;
+}
+
+main .search-results-pagination .search-results-pagination-item > button.arrow {
+  border: 2px solid var(--clr-teal);
+}
+
+main .search-results-pagination .search-results-pagination-item > button.active {
+  font-weight: bold;
+}
+
+main .search-results-pagination.dark-bg .search-results-pagination-item > button {
+  color: var(--clr-white);
+}
+
+main .search-results-pagination.dark-bg .search-results-pagination-item > button.active {
+  background-color: var(--clr-white);
+  color: var(--clr-teal);
+}
+
+main .search-results-pagination.dark-bg .search-results-pagination-item > button.arrow {
+  background-color: transparent;
+  border: 2px solid var(--clr-white);
+  color: var(--clr-teal-light);
+}
+
+
+@media (min-width: 900px) {
+  main .search-results-pagination .search-results-pagination-item > button {
+    font-size: var(--body-font-size-xl);
+    padding: 0.5rem 1rem;
+  }
+
+  main .search-results-pagination .search-results-pagination-item {
+    margin: 0 0.5rem;
+  }
 }

--- a/tools/sidekick/tagger/tagger.js
+++ b/tools/sidekick/tagger/tagger.js
@@ -1,4 +1,4 @@
-import getTaxonomy from '../../../scripts/taxonomy.js';
+import { getTaxonomy } from '../../../scripts/taxonomy.js';
 
 function renderItem(item, catId) {
   const pathStr = item.path.split('/').slice(0, -1).join('<span class="psep"> / </span>');


### PR DESCRIPTION
Fix #101 #102 #148 

## Summary
- Implements a locator block and a locator results block, which can be configured as an office or agency search.
- Results per page can be configured for the locator results block at a block level. Default is 10.
- Until we have a reliable method to proxy requests to the `esb` API, basic auth credentials need to be passed as `esbUser` and `esbPass` URL parameters for the API calls to work. If anyone needs these for testing, ask in the slack channel or DM me.
- Office Locator and Agency Locator have been created as fragments as they need to be placed inside a columns block in both cases. See fragments [here](https://adobe.sharepoint.com/sites/HelixProjects/Shared%20Documents/Forms/AllItems.aspx?ga=1&id=%2Fsites%2FHelixProjects%2FShared%20Documents%2Fsites%2Fstewart%2Dtitle%2Fen%2Ffragments%2Flocators&viewid=124ad5f1%2D60ba%2D476c%2Dade8%2D7c1df274ee95)

## Test URLs
**Before**
- https://main--stewart--hlxsites.hlx.page/en
- https://main--stewart--hlxsites.hlx.page/en/locate-an-office
- https://main--stewart--hlxsites.hlx.page/en/agent-verification

**After**
- https://feature-locator-blocks--stewart--hlxsites.hlx.page/en
- https://feature-locator-blocks--stewart--hlxsites.hlx.page/en/locate-an-office
- https://feature-locator-blocks--stewart--hlxsites.hlx.page/en/agent-verification