### PR TITLE
fix Table block not rendering when there are no content rows #111

### DIFF
--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -12,7 +12,7 @@ function buildCell(rowIndex) {
 
 export default async function decorate(block) {
   // if the block has one child which is a table, replace the block with the table
-  if (block.children.length === 1 || block.children[0].tagName === 'TABLE') {
+  if (block.children.length === 1 && block.children[0].tagName === 'TABLE') {
     block.innerHTML = block.children[0].innerHTML;
     return;
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

If your PR introduces a new block/black varaint, please update the block library https://main--stewart--hlxsites.hlx.page/tools/sidekick/library/library.html

Test URLs:
- Before: https://main--stewart--hlxsites.hlx.live/en/education-and-training/sureclose-advantage
- After: https://fix-table--stewart--hlxsites.hlx.live/en/education-and-training/sureclose-advantage
